### PR TITLE
Improve SearchIndexArgs structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,21 @@ pip install opensearch-mcp-server-py
 ## Available tools
 - ListIndexTool: Lists all indices in OpenSearch.
 - IndexMappingTool: Retrieves index mapping and setting information for an index in OpenSearch.
-- SearchIndexTool: Searches an index using a query written in query domain-specific language (DSL) in OpenSearch.
+- SearchIndexTool: Searches an index using a query written in query DSL and supports optional ``size``, ``from``, ``sort``, and ``aggs`` parameters.
 - GetShardsTool: Gets information about shards in OpenSearch.
 
 > More tools coming soon. [Click here](DEVELOPER_GUIDE.md#contributing)
+
+### SearchIndexTool parameters
+
+The search request body supports common OpenSearch options:
+
+- **index** – name of the index to search.
+- **query** – query DSL describing which documents to match.
+- **size** – maximum number of hits to return (defaults to 10 if not provided).
+- **from** – starting offset for hits (useful for pagination).
+- **sort** – sorting criteria for the results.
+- **aggs** – aggregations to compute over matched documents.
 
 ## User Guide
 For detailed usage instructions, configuration options, and examples, please see the [User Guide](USER_GUIDE.md).

--- a/src/tools/args.py
+++ b/src/tools/args.py
@@ -1,0 +1,79 @@
+"""Argument models for tools."""
+
+from pydantic import BaseModel, Field, ConfigDict
+from typing import Any
+import os
+
+
+class ListIndicesArgs(BaseModel):
+    """Arguments for listing all indices."""
+
+    opensearch_url: str = Field(
+        default=os.getenv("OPENSEARCH_URL", ""),
+        description="OpenSearch cluster URL",
+    )
+
+
+class GetIndexMappingArgs(BaseModel):
+    """Arguments for retrieving index mappings."""
+
+    index: str = Field(..., description="Name of the index")
+    opensearch_url: str = Field(
+        default=os.getenv("OPENSEARCH_URL", ""),
+        description="OpenSearch cluster URL",
+    )
+
+
+class SearchIndexArgs(BaseModel):
+    """Arguments for the SearchIndexTool."""
+
+    index: str = Field(..., description="Name of the index to search")
+    query: dict[str, Any] = Field(
+        ...,
+        description=(
+            "Query DSL describing which documents to match. Placed in the "
+            "`query` section of the search request body."
+        ),
+    )
+    size: int | None = Field(
+        default=None,
+        description=(
+            "Maximum number of search hits to return. Defaults to 10 when"
+            " omitted."
+        ),
+    )
+    from_: int | None = Field(
+        default=None,
+        alias="from",
+        description=(
+            "How many search hits to skip before returning results. Useful "
+            "for pagination."
+        ),
+    )
+    sort: list[Any] | None = Field(
+        default=None,
+        description="List of sort directives for ordering search results",
+    )
+    aggs: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Aggregations to compute over the matched documents, keyed by "
+            "aggregation name."
+        ),
+    )
+    opensearch_url: str = Field(
+        default=os.getenv("OPENSEARCH_URL", ""),
+        description="OpenSearch cluster URL",
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class GetShardsArgs(BaseModel):
+    """Arguments for retrieving shard information."""
+
+    index: str = Field(..., description="Name of the index")
+    opensearch_url: str = Field(
+        default=os.getenv("OPENSEARCH_URL", ""),
+        description="OpenSearch cluster URL",
+    )

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -1,27 +1,19 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from pydantic import BaseModel
-from opensearch.helper import list_indices, get_index_mapping, search_index, get_shards
-from typing import Any
+from opensearch.helper import (
+    list_indices,
+    get_index_mapping,
+    search_index,
+    get_shards,
+)
+from .args import (
+    ListIndicesArgs,
+    GetIndexMappingArgs,
+    SearchIndexArgs,
+    GetShardsArgs,
+)
 import json
-import os
-
-class ListIndicesArgs(BaseModel):
-    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
-
-class GetIndexMappingArgs(BaseModel):
-    index: str
-    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
-
-class SearchIndexArgs(BaseModel):
-    index: str
-    query: Any
-    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
-
-class GetShardsArgs(BaseModel):
-    index: str
-    opensearch_url: str = os.getenv("OPENSEARCH_URL", "")
 
 async def list_indices_tool(args: ListIndicesArgs) -> list[dict]:
     try:
@@ -56,7 +48,21 @@ async def get_index_mapping_tool(args: GetIndexMappingArgs) -> list[dict]:
 
 async def search_index_tool(args: SearchIndexArgs) -> list[dict]:
     try:
-        result = search_index(args.opensearch_url, args.index, args.query)
+        body = {"query": args.query}
+
+        if args.size is not None:
+            body["size"] = args.size
+
+        if args.from_ is not None:
+            body["from"] = args.from_
+
+        if args.sort is not None:
+            body["sort"] = args.sort
+
+        if args.aggs is not None:
+            body["aggs"] = args.aggs
+
+        result = search_index(args.opensearch_url, args.index, body)
         formatted_result = json.dumps(result, indent=2)
         
         return [{

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -173,7 +173,11 @@ class TestTools():
         assert result[0]['type'] == 'text'
         assert 'Search results from test-index' in result[0]['text']
         assert json.loads(result[0]['text'].split('\n', 1)[1]) == mock_results
-        self.mock_search.assert_called_once_with(self.test_url, "test-index", {"match_all": {}})
+        self.mock_search.assert_called_once_with(
+            self.test_url,
+            "test-index",
+            {"query": {"match_all": {}}},
+        )
     
     @pytest.mark.asyncio
     async def test_search_index_tool_error(self):
@@ -192,7 +196,11 @@ class TestTools():
         assert len(result) == 1
         assert result[0]['type'] == 'text'
         assert 'Error searching index: Test error' in result[0]['text']
-        self.mock_search.assert_called_once_with(self.test_url, "test-index", {"match_all": {}})
+        self.mock_search.assert_called_once_with(
+            self.test_url,
+            "test-index",
+            {"query": {"match_all": {}}},
+        )
 
     @pytest.mark.asyncio
     async def test_get_shards_tool(self):
@@ -262,6 +270,14 @@ class TestTools():
 
         # Test valid inputs
         assert self.GetIndexMappingArgs(opensearch_url=self.test_url, index="test").index == "test"
-        assert self.SearchIndexArgs(opensearch_url=self.test_url, index="test", query={"match": {}}).index == "test"
+        assert (
+            self.SearchIndexArgs(
+                opensearch_url=self.test_url,
+                index="test",
+                query={"match": {}},
+                **{"from": 1},
+            ).from_
+            == 1
+        )
         assert self.GetShardsArgs(opensearch_url=self.test_url, index="test").index == "test"
         assert isinstance(self.ListIndicesArgs(opensearch_url=self.test_url), self.ListIndicesArgs)


### PR DESCRIPTION
## Summary
- move argument models into `tools/args.py`
- remove references to external docs from README and arg descriptions
- import argument classes in `tools.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_685028ccab988323b137e5b740619756